### PR TITLE
Create AnalogSlicer_1.2.R

### DIFF
--- a/AnalogSlicer_1.2.R
+++ b/AnalogSlicer_1.2.R
@@ -2,19 +2,23 @@
 # input = input text file, in Spheregen format, with the first line as a vacuole.  
 # balls - ball locations
 # r - ball radii
-# z - location (in z dimension) of slice - 
+# zloc - can be "center" or "random."  Defines the z location of the slice plane
 # T - slice thickness
 # calculates the maximum radius of each ball that is caught in the slice
-slice1 = function(input, T = 5, vacmin = 50) {
+slice1 = function(input, zloc = "center", T = 5, vacmin = 50) {
    inputfile = read.table(input, sep = " ")  
    r = inputfile [2:nrow(inputfile),1] # creates a vector of the radii of all of bodies
    upside_down_balls = t(inputfile[2:nrow(inputfile),2:4])
    balls = apply(upside_down_balls, 2, rev) # locations of the bodies, with each column a body, and then the rows the (x, y, z) coordinates, top to bottom
    scale = inputfile[1,1] # takes the scale from the size of the vacuole
-   z = inputfile[1,2] # takes the plane through which to slice from the center of the vacuole
    cellSize = 2*scale
-   #zbound = scale-sqrt(scale^2-vacmin^2)
-   #z = (runif(1, min=(0+zbound), max=(cellSize-zbound)))  Random Z, with bounds that guarranty that a slice of the vacuole at least vacmin large is cut.  But for now I'm just putting Z through the origin for reproducibility
+   if (zloc == "center") {
+      z = inputfile[1,2] # takes the plane through which to slice from the center of the vacuole  
+   } else if (zloc == "random") {
+   zbound = scale-sqrt(scale^2-vacmin^2)
+   z = (runif(1, min=(0+zbound), max=(cellSize-zbound))) # Random Z, with bounds that guaranty that a slice of the vacuole at least vacmin large is cut.  But for now I'm just putting Z through the origin for reproducibility
+   print (c("The slice location is", z))
+   }
    RR = NULL
    for (j in 1:length(r)) {
       # loops for the number of balls
@@ -36,9 +40,3 @@ slice1 = function(input, T = 5, vacmin = 50) {
    
    list(rrmax=RR)
 }
-
-# Seems to work, but test more.  
-# balls = matrix(c(110, 110, 110, 45, 50, 55), nrow = 3)
-# r = c(40, 20)
-# scale = 110
-# z = 110


### PR DESCRIPTION
AnalogSlicer uses the slicing code from the old R simulation that calculates the area of a slice based directly on a radius and distance from center of the slice, no pixels involved.  It takes an input file structured the same as the input file for spheregen, with the first line being the vacuole.  This is to use to compare the output against that made by a Spheregen -> Slicestats pipeline.   